### PR TITLE
Smart/smart main

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/smart/SmartCapabilityStatementInterceptorR4.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/smart/SmartCapabilityStatementInterceptorR4.java
@@ -1,0 +1,110 @@
+package ca.uhn.fhir.jpa.starter.smart;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.instance.model.api.IBaseConformance;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.UriType;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestComponent;
+import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestSecurityComponent;
+import org.hl7.fhir.r4.model.CapabilityStatement.RestfulCapabilityMode;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+
+@Interceptor
+public class SmartCapabilityStatementInterceptorR4 {
+
+	private String authorizationEndpoint;
+	private String tokenEndpoint;
+	private String managementEndpoint;
+	private String introspectionEndpoint;
+	private String revocationEndpoint;
+
+	public SmartCapabilityStatementInterceptorR4(String authorizationEndpoint, String tokenEndpoint, String managementEndpoint, String introspectionEndpoint, String revocationEndpoint) {
+		super();
+		this.authorizationEndpoint = authorizationEndpoint;
+		this.tokenEndpoint = tokenEndpoint;
+		this.managementEndpoint = managementEndpoint;
+		this.introspectionEndpoint = introspectionEndpoint;
+		this.revocationEndpoint = revocationEndpoint;
+	}
+
+	@Hook(Pointcut.SERVER_CAPABILITY_STATEMENT_GENERATED)
+	public void customize(IBaseConformance theCapabilityStatement) {
+
+		// Cast to the appropriate version
+		CapabilityStatement cs = (CapabilityStatement) theCapabilityStatement;
+
+
+		// Customize the CapabilityStatement as desired
+		// cs.getSoftware().setName("Acme FHIR Server").setVersion("1.0").setReleaseDateElement(new DateTimeType("2021-02-06"));
+
+		CapabilityStatementRestSecurityComponent securityComponent = this.buildSecurityComponent();
+
+		// Get the CapabilityStatementRestComponent for the server if one exists
+		List<CapabilityStatementRestComponent> restComponents = cs.getRest();
+		CapabilityStatementRestComponent rest = null;
+		for (CapabilityStatementRestComponent rc : restComponents) {
+			if (rc.getMode().equals(RestfulCapabilityMode.SERVER)) {
+				rest = rc;
+				break;
+			}
+		}
+
+		if (rest == null) {
+			// Create new rest component
+			rest = new CapabilityStatementRestComponent();
+			rest.setMode(RestfulCapabilityMode.SERVER);
+			rest.setSecurity(securityComponent);
+			cs.addRest(rest);
+		} else {
+			rest.setSecurity(securityComponent);
+		}
+
+	}
+
+	private CapabilityStatementRestSecurityComponent buildSecurityComponent() {
+		CapabilityStatementRestSecurityComponent securityComponent = new CapabilityStatementRestSecurityComponent();
+
+		// see http://hl7.org/fhir/smart-app-launch/1.0.0/conformance/index.html#example
+		CodeableConcept cc = securityComponent.addService();
+		cc.addCoding(new Coding("http://hl7.org/fhir/restful-security-service", "SMART-on-FHIR", null));
+		cc.setText("OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)");
+
+		Extension oauthExtension = new Extension();
+
+		oauthExtension.setUrl("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris");
+		List<Extension> extensions = new ArrayList<>();
+		if (StringUtils.trimToNull(this.tokenEndpoint) != null) {
+			extensions.add(new Extension("token", new UriType(this.tokenEndpoint)));
+		}
+
+		if (StringUtils.trimToNull(this.authorizationEndpoint) != null) {
+			extensions.add(new Extension("authorize", new UriType(this.authorizationEndpoint)));
+		}
+
+		if (StringUtils.trimToNull(this.managementEndpoint) != null) {
+			extensions.add(new Extension("manage", new UriType(this.managementEndpoint)));
+		}
+
+		if (StringUtils.trimToNull(this.introspectionEndpoint) != null) {
+			extensions.add(new Extension("introspect", new UriType(this.introspectionEndpoint)));
+		}
+
+		if (StringUtils.trimToNull(this.revocationEndpoint) != null) {
+			extensions.add(new Extension("revoke", new UriType(this.revocationEndpoint)));
+		}
+
+		oauthExtension.setExtension(extensions);
+		securityComponent.addExtension(oauthExtension);
+
+		return securityComponent;
+	}
+}
+

--- a/src/main/java/ca/uhn/fhir/jpa/starter/smart/model/SmartClinicalScope.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/smart/model/SmartClinicalScope.java
@@ -16,6 +16,8 @@ import ca.uhn.fhir.jpa.starter.smart.exception.InvalidClinicalScopeException;
 
 public class SmartClinicalScope {
 
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(SmartClinicalScope.class);
+	
 	private final String compartment;
 	private final String resource;
 	private final SmartOperationEnum operation;
@@ -36,7 +38,24 @@ public class SmartClinicalScope {
 		} else{
 			throw new InvalidClinicalScopeException(scope+" is not a valid clinical scope");
 		}
-
+	}
+	
+	/**
+	 * Utility for creating SMART scopes - this method will return null if the scope format is not recognized
+	 * @param scope the scope string, ex ) patient/Patient.read, patient/*.read, etc.
+	 * @return a SmartClinicalScope if the formatting is valid
+	 */
+	public static SmartClinicalScope createIfValidSmartClinicalScope(String scope) {
+		
+		//this method doesnt do anything special yet, but made it to allow for making smarter determinations
+		//if necessary at some point (checking the compartment/resource values, etc.)
+		try {
+			return new SmartClinicalScope(scope);
+		}
+		catch(Exception e) {
+			ourLog.debug("Ignoring unknown scope: {}", scope);
+			return null;
+		}
 	}
 
 	public String getCompartment(){

--- a/src/main/java/ca/uhn/fhir/jpa/starter/smart/model/SmartClinicalScope.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/smart/model/SmartClinicalScope.java
@@ -17,7 +17,7 @@ import ca.uhn.fhir.jpa.starter.smart.exception.InvalidClinicalScopeException;
 public class SmartClinicalScope {
 
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(SmartClinicalScope.class);
-	
+
 	private final String compartment;
 	private final String resource;
 	private final SmartOperationEnum operation;
@@ -26,6 +26,11 @@ public class SmartClinicalScope {
 		this.compartment = compartment;
 		this.resource = resource;
 		this.operation = operation;
+	}
+
+	@Override
+	public String toString() {
+		return "SmartClinicalScope [compartment=" + compartment + ", resource=" + resource + ", operation=" + operation + "]";
 	}
 
 	public SmartClinicalScope(String scope) {
@@ -39,14 +44,14 @@ public class SmartClinicalScope {
 			throw new InvalidClinicalScopeException(scope+" is not a valid clinical scope");
 		}
 	}
-	
+
 	/**
 	 * Utility for creating SMART scopes - this method will return null if the scope format is not recognized
 	 * @param scope the scope string, ex ) patient/Patient.read, patient/*.read, etc.
 	 * @return a SmartClinicalScope if the formatting is valid
 	 */
 	public static SmartClinicalScope createIfValidSmartClinicalScope(String scope) {
-		
+
 		//this method doesnt do anything special yet, but made it to allow for making smarter determinations
 		//if necessary at some point (checking the compartment/resource values, etc.)
 		try {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/smart/security/interceptor/SmartScopeAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/smart/security/interceptor/SmartScopeAuthorizationInterceptor.java
@@ -5,7 +5,6 @@ import ca.uhn.fhir.jpa.starter.smart.exception.InvalidSmartOperationException;
 import ca.uhn.fhir.jpa.starter.smart.model.SmartClinicalScope;
 import ca.uhn.fhir.jpa.starter.smart.security.builder.SmartAuthorizationRuleBuilder;
 import ca.uhn.fhir.jpa.starter.smart.util.JwtUtility;
-import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.interceptor.auth.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +12,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.stereotype.Component;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,16 +24,21 @@ import static ca.uhn.fhir.jpa.starter.smart.util.JwtUtility.getSmartScopes;
 @Component
 public class SmartScopeAuthorizationInterceptor extends AuthorizationInterceptor {
 
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(SmartScopeAuthorizationInterceptor.class);
+
 	private final List<SmartAuthorizationRuleBuilder> ruleBuilders;
 	public static final String RULE_DENY_ALL_UNKNOWN_REQUESTS = "Deny all requests that do not match any pre-defined rules";
 
 	private final JwtDecoder jwtDecoder;
-	
+
 	@Value("${hapi.fhir.smart_admin_group_enabled}")
 	private boolean smartAdminAccessEnabled;
-	
+
 	@Value("${hapi.fhir.smart_admin_group_claim}")
 	private String smartAdminGroupClaim;
+
+	@Value("${smart.allowed_readonly_resources}")
+	private List<String> allowedReadOnlyResources;
 
 	public SmartScopeAuthorizationInterceptor(List<SmartAuthorizationRuleBuilder> ruleBuilders, JwtDecoder jwtDecoder) {
 		this.setFlags(AuthorizationFlagsEnum.DO_NOT_PROACTIVELY_BLOCK_COMPARTMENT_READ_ACCESS);
@@ -45,53 +50,88 @@ public class SmartScopeAuthorizationInterceptor extends AuthorizationInterceptor
 	public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
 		Jwt token = JwtUtility.getJwtToken(jwtDecoder, theRequestDetails);
 		IAuthRuleBuilder authRuleBuilder = new RuleBuilder();
-		List<IAuthRule> ruleList = new ArrayList<>(authRuleBuilder.allow().metadata().build());
+
+		// allow metadata
+		authRuleBuilder.allow().metadata();
+
+		List<IAuthRule> ruleList = new ArrayList<>();
 
 		if (token == null) {
-			return ruleList;
+			return authRuleBuilder.build();
 		}
-		
+
 		// Check if admin user
 		if( smartAdminAccessEnabled && smartAdminGroupClaim != null ) {
-			
+
 			List<String> groups = token.getClaimAsStringList("group");
 			if( groups != null ) {
 				for( String group : groups ) {
 					if ( smartAdminGroupClaim.equals(group) ) {
-						ruleList.addAll(authRuleBuilder.allowAll().build());
+						authRuleBuilder.allowAll();
 						//can short-circuit here since we are returning a rule with unrestricted access
-						return ruleList;
+						return authRuleBuilder.build();
 					}
 				}
 			}
 		}
-		
+
 		try {
 			Set<SmartClinicalScope> scopes = getSmartScopes(token);
 			Map<String, Object> claims = token.getClaims();
 			for (SmartClinicalScope scope : scopes) {
 				String compartmentName = scope.getCompartment();
 				if (compartmentName != null && !compartmentName.isEmpty()) {
+
+					// Since we'll be using different builder(s) to create the SMART scope rules
+					// we need to add the rules created to this point to the return list and reset our builder
+					// so we don't the same rules to the list twice.
+					ruleList.addAll(authRuleBuilder.build());
+					authRuleBuilder = new RuleBuilder(); // reset so we don't re-add the rules to the list twice
+
+					// create rules for all the SMART scopes in the token
 					ruleBuilders.stream().filter(smartAuthorizationRuleBuilder -> smartAuthorizationRuleBuilder.hasRegisteredResource(compartmentName)).forEach(smartAuthorizationRuleBuilder -> {
+
 						String launchCtxName = smartAuthorizationRuleBuilder.getLaunchCtxName(compartmentName);
 						String launchCtx = (String) claims.get(launchCtxName);
-						if (theRequestDetails.getRequestType().equals(RequestTypeEnum.GET) && theRequestDetails.getId() == null){
-							if(scope.getResource().equalsIgnoreCase("*")){
+
+						ruleList.addAll(smartAuthorizationRuleBuilder.buildRules(launchCtx, scope));
+
+						// removed code
+						/*if (theRequestDetails.getRequestType().equals(RequestTypeEnum.GET) && theRequestDetails.getId() == null) {
+							if (scope.getResource().equalsIgnoreCase("*")) {
 								ruleList.addAll(authRuleBuilder.allow().read().allResources().withAnyId().build());
-							} else ruleList.addAll(authRuleBuilder.allow().read().resourcesOfType(scope.getResource()).withAnyId().build());
+							} else {
+								ruleList.addAll(authRuleBuilder.allow().read().resourcesOfType(scope.getResource()).withAnyId().build());
+							}
 						} else {
 							ruleList.addAll(smartAuthorizationRuleBuilder.buildRules(launchCtx, scope));
-						}
+						}*/
 					});
 				}
 			}
-			ruleList.addAll(authRuleBuilder.denyAll(RULE_DENY_ALL_UNKNOWN_REQUESTS).build());
+
+			// add supplemental rules
+			for (String resourceName : allowedReadOnlyResources) {
+				authRuleBuilder.allow().read().resourcesOfType(resourceName).withAnyId();
+			}
+
 		} catch (InvalidClinicalScopeException | InvalidSmartOperationException e) {
-			ruleList.addAll(authRuleBuilder.denyAll(e.getMessage()).build());
+			ourLog.error("caught e->{}", e, e);
+			// return a deny all rule
+			return new RuleBuilder().denyAll(e.getMessage()).build();
 		}
+
+		// add a final deny all to catch anything that falls through
+		authRuleBuilder.denyAll(RULE_DENY_ALL_UNKNOWN_REQUESTS);
+		ruleList.addAll(authRuleBuilder.build());
+
+		/*for (IAuthRule rule : ruleList) {
+			String ruleStr = rule.toString();
+			ourLog.debug("  our list ruleStr->{}", ruleStr);
+		}*/
+
 
 		return ruleList;
 	}
-
 
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/smart/security/interceptor/SmartSearchNarrowingInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/smart/security/interceptor/SmartSearchNarrowingInterceptor.java
@@ -56,6 +56,15 @@ public class SmartSearchNarrowingInterceptor extends SearchNarrowingInterceptor 
 						if (operationEnum.equals(SmartOperationEnum.WRITE)) {
 							throw new ForbiddenOperationException("Read scope is required when performing a narrowing search operation");
 						}
+
+						// the compartment names are coming from the scopes and are lower-case.
+						// need them to match resource names for the search narrowing interceptor to work
+						if ("patient".equals(compartmentName)) {
+							compartmentName = "Patient";
+						} else if ("user".equals(compartmentName)) {
+							compartmentName = "Practitioner";
+						}
+
 						authorizedList.addCompartment(String.format("%s/%s", compartmentName, id));
 					} else {
 						throw new AuthenticationException("Compartment is required when performing a narrowing search operation");

--- a/src/main/java/ca/uhn/fhir/jpa/starter/smart/util/JwtUtility.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/smart/util/JwtUtility.java
@@ -35,7 +35,10 @@ public class JwtUtility {
 			String[] scopes = token.getClaimAsString("scope").split(" ");
 
 			for (String scope : scopes) {
-				smartClinicalScopes.add(new SmartClinicalScope(scope));
+				SmartClinicalScope smartScope = SmartClinicalScope.createIfValidSmartClinicalScope(scope);
+				if( smartScope != null ) {
+					smartClinicalScopes.add(smartScope);
+				}
 			}
 			return smartClinicalScopes;
 		} catch (NullPointerException e){

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -224,8 +224,11 @@ hapi:
 #  schema_management_strategy: CREATE
 #  username: SomeUsername
 
-# see https://hl7.org/fhir/smart-app-launch/conformance.html#response
-smart: 
+smart:
+  #resources to allow unresticted read access to - generally things outside of patient compartment 
+  #note: List is not included by default since it could contain anything, but would be needed to support DaVinci Forumulary
+  allowed_readonly_resources: Practitioner, PractitionerRole, Organization, OrganizationAffiliation, MedicationKnowledge, Location, HealthcareService
+  # see https://hl7.org/fhir/smart-app-launch/conformance.html#response
   wellknown: 
     issuer: 
     jwks_uri: 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/AuthorizationInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/AuthorizationInterceptorTest.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -253,11 +254,32 @@ class AuthorizationInterceptorTest {
 
 	@ParameterizedTest
 	@MethodSource("getReadPatientClinicalScopes")
-	void testBuildRules_readPatient_providedJwtContainsReadScopesButWrongPatientIdAsAdmin(Map<String, Object> claims) {
+	void testBuildRules_searchPatient_providedJwtContainsReadScopesButWrongPatientId(Map<String, Object> claims) {
+
 		// ARRANGE
 		IBaseResource mockPatient = patientResourceDao.create(new Patient()).getResource();
 		String mockId = mockPatient.getIdElement().getIdPart();
 
+		claims.put("patient", "wrong");
+		mockJwtWithClaims(claims);
+
+		IQuery<IBaseBundle> patientReadExecutable = client.search().forResource(Patient.class)
+				.where(Patient.RES_ID.exactly().code(mockId)).withAdditionalHeader("Authorization", MOCK_HEADER);
+
+		ForbiddenOperationException forbiddenOperationException = assertThrows(ForbiddenOperationException.class,
+				patientReadExecutable::execute);
+
+		// ASSERT
+		Assertions.assertTrue(forbiddenOperationException.getMessage().contains("HTTP 403"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("getReadPatientClinicalScopes")
+	void testBuildRules_readPatient_providedJwtContainsReadScopesButWrongPatientIdAsAdmin(Map<String, Object> claims) {
+
+		// ARRANGE
+		IBaseResource mockPatient = patientResourceDao.create(new Patient()).getResource();
+		String mockId = mockPatient.getIdElement().getIdPart();
 
 		claims.put("patient", "wrong");
 		claims.put("group", smartAdminGroupClaim);
@@ -272,7 +294,6 @@ class AuthorizationInterceptorTest {
 		// ASSERT
 		assertEquals(mockId, actualPatient.getIdElement().getIdPart());
 	}
-
 
 	@ParameterizedTest
 	@MethodSource({"getAllPatientClinicalScopes", "getWriteObservationClinicalScopes"})
@@ -869,6 +890,31 @@ class AuthorizationInterceptorTest {
 		assertEquals(searchBundle.getEntry().get(0).getResource().getIdElement().getIdPart(), id);
 	}
 
+	@ParameterizedTest
+	@MethodSource({ "getReadPatientClinicalScopes" })
+	void testBuildRules_searchOperation_providedJwtContainsReadScope_multiplePatients(Map<String, Object> claims) {
+		// ARRANGE
+
+		IBaseResource expectedPatient = patientResourceDao.create(new Patient()).getResource();
+		String id = expectedPatient.getIdElement().getIdPart();
+
+		// add a second patient to make sure the narrowing interceptor works
+		patientResourceDao.create(new Patient());
+
+		claims.put("patient", id);
+		mockJwtWithClaims(claims);
+
+		IQuery<IBaseBundle> patientSearchExecutable = client.search().forResource(Patient.class)
+				.withAdditionalHeader("Authorization", MOCK_HEADER);
+
+		// ACT
+		Bundle searchBundle = (Bundle) patientSearchExecutable.execute();
+
+		// ASSERT
+		assertEquals(1, searchBundle.getEntry().size());
+		assertEquals(searchBundle.getEntry().get(0).getResource().getIdElement().getIdPart(), id);
+	}
+
 	@Test
 	void testBuildRules_searchOperation_providedJwtContainsWriteScope() {
 		// ARRANGE
@@ -929,6 +975,65 @@ class AuthorizationInterceptorTest {
 
 		// ASSERT
 		assertEquals(String.format("HTTP 403 : %s is not a valid clinical scope", randomScope), authenticationException.getMessage());
+	}
+
+	@Test
+	void testBuildRules_searchRecords_wrongPatient_providedJwtContainsReadScopesAndPatientId() {
+
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("scope", "patient/*.read");
+
+		// create a patient
+		IBaseResource patient = patientResourceDao.create(new Patient()).getResource();
+		String patId = patient.getIdElement().getIdPart();
+
+		// create an observation for the patient
+		IBaseResource observation = observationResourceDao
+				.create(new Observation().setSubject(new Reference(patient.getIdElement()))).getResource();
+		String obsId = observation.getIdElement().getIdPart();
+
+		// get a claim for a different patient ID
+		claims.put("patient", "wrong");
+		// claims.put("patient", patId);
+		mockJwtWithClaims(claims);
+
+		ForbiddenOperationException exception = Assertions.assertThrows(ForbiddenOperationException.class, () -> {
+			// search for our Observation /Observation?subject=Patient/xxx
+			// we should not be able to see these records
+			Bundle searchBundle = client.search().forResource(Observation.class)
+					.where(Observation.SUBJECT.hasId("Patient/" + patId)).returnBundle(Bundle.class)
+					.withAdditionalHeader("Authorization", MOCK_HEADER).execute();
+		});
+
+		Assertions.assertTrue(exception.getMessage().contains("HTTP 403"));
+	}
+
+	@Test
+	void testBuildRules_searchRecords_correctPatient_providedJwtContainsReadScopesAndPatientId() {
+
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("scope", "patient/*.read");
+
+		// create a patient
+		IBaseResource patient = patientResourceDao.create(new Patient()).getResource();
+		String patId = patient.getIdElement().getIdPart();
+
+		// create an observation for the patient
+		IBaseResource observation = observationResourceDao
+				.create(new Observation().setSubject(new Reference(patient.getIdElement()))).getResource();
+		String obsId = observation.getIdElement().getIdPart();
+
+		claims.put("patient", patId);
+		mockJwtWithClaims(claims);
+
+		// search for our Observation /Observation?subject=Patient/xxx
+		// we should not be able to see these records
+		Bundle searchBundle = client.search().forResource(Observation.class)
+				.where(Observation.SUBJECT.hasId("Patient/" + patId)).returnBundle(Bundle.class)
+				.withAdditionalHeader("Authorization", MOCK_HEADER).execute();
+
+		assertEquals(1, searchBundle.getEntry().size());
+		assertEquals(searchBundle.getEntry().get(0).getResource().getIdElement().getIdPart(), obsId);
 	}
 
 	private static Stream<Arguments> getReadPatientClinicalScopes() {

--- a/src/test/java/ca/uhn/fhir/jpa/starter/AuthorizationInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/AuthorizationInterceptorTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -146,42 +145,6 @@ class AuthorizationInterceptorTest {
 
 		// ASSERT
 		assertEquals(ACCESS_DENIED_DUE_TO_SCOPE_RULE_EXCEPTION_MESSAGE, forbiddenOperationException.getMessage());
-	}
-
-	@ParameterizedTest
-	@ValueSource(strings = {"", "random/thing"})
-	void testBuildRules_readPatient_badScope(String clinicalScope) {
-		// ARRANGE
-		String mockId = "123";
-
-		HashMap<String, Object> claims = new HashMap<>();
-
-		claims.put("scope", clinicalScope);
-
-		mockJwtWithClaims(claims);
-		// ACT
-		IReadExecutable<IBaseResource> patientReadExecutable = client.read().resource("Patient").withId(mockId).withAdditionalHeader("Authorization", MOCK_HEADER);
-		ForbiddenOperationException forbiddenOperationException = assertThrows(ForbiddenOperationException.class, patientReadExecutable::execute);
-
-		// ASSERT
-		assertEquals("HTTP 403 : "+clinicalScope+" is not a valid clinical scope", forbiddenOperationException.getMessage());
-	}
-
-	@Test
-	void testBuildRules_readPatient_invalidClinicalScopeOperation() {
-		// ARRANGE
-		String mockId = "123";
-
-		HashMap<String, Object> claims = new HashMap<>();
-		claims.put("scope", "random/thing.unsupported");
-		mockJwtWithClaims(claims);
-
-		// ACT
-		IReadExecutable<IBaseResource> patientReadExecutable = client.read().resource("Patient").withId(mockId).withAdditionalHeader("Authorization", MOCK_HEADER);
-		ForbiddenOperationException forbiddenOperationException = assertThrows(ForbiddenOperationException.class, patientReadExecutable::execute);
-
-		// ASSERT
-		assertEquals("HTTP 403 : unsupported is not a legal operation", forbiddenOperationException.getMessage());
 	}
 
 	@Test
@@ -955,26 +918,25 @@ class AuthorizationInterceptorTest {
 		// ASSERT
 		assertEquals("HTTP 403 : No scope provided", authenticationException.getMessage());
 	}
-
-	@Test
-	void testBuildRules_searchOperation_invalidScope() {
+	
+	@ParameterizedTest
+	@MethodSource({"getWriteObservationUnknownScopes"})
+	void testBuildRules_createObservationOnPatient_providedJwtContainsWriteScopesAndPatientIdAndUnknownScopes(Map<String, Object> claims) {
 		// ARRANGE
-		String randomScope = UUID.randomUUID().toString();
-		IBaseResource expectedPatient = patientResourceDao.create(new Patient()).getResource();
-		String id=expectedPatient.getIdElement().getIdPart();
+		IBaseResource mockPatient = patientResourceDao.create(new Patient()).getResource();
+		String mockId = mockPatient.getIdElement().getIdPart();
 
-		Map<String, Object> claims = new HashMap<>();
-		claims.put("patient", id);
-		claims.put("scope", randomScope);
+		claims.put("patient", mockId);
 		mockJwtWithClaims(claims);
 
-		IQuery<IBaseBundle> patientSearchExecutable = client.search().forResource(Patient.class).withAdditionalHeader("Authorization", MOCK_HEADER);
-
 		// ACT
-		ForbiddenOperationException authenticationException = assertThrows(ForbiddenOperationException.class, patientSearchExecutable::execute);
+		Observation observation = new Observation();
+		observation.setSubject(new Reference(mockPatient.getIdElement()));
+		ICreateTyped observationCreateExecutable = client.create().resource(observation).withAdditionalHeader("Authorization", MOCK_HEADER);
+		MethodOutcome outcome = observationCreateExecutable.execute();
 
 		// ASSERT
-		assertEquals(String.format("HTTP 403 : %s is not a valid clinical scope", randomScope), authenticationException.getMessage());
+		assertTrue(outcome.getCreated());
 	}
 
 	@Test
@@ -1136,6 +1098,20 @@ class AuthorizationInterceptorTest {
 						}}
 						)
 				);
+	}
+	
+	/**
+	 * 
+	 * @return return scopes unknown to SMART authorization which may be in the JWT token, such as launch/patient 
+	 */
+	private static Stream<Arguments> getWriteObservationUnknownScopes() {
+		return Stream.of(
+			Arguments.of(
+				new HashMap<String, String>() {{
+					put("scope", "launch/patient patient/Observation.*");
+				}}
+			)
+		);
 	}
 
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/WellKnownControllerTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/WellKnownControllerTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.starter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,9 @@ class WellKnownControllerTest {
 	private int port;
 	private String ourServerBase;
 
+	@Value("${smart.wellknown.authorization_endpoint}")
+	public String authorizationEndpoint;
+
 	@BeforeEach
 	void setUp() {
 		ourServerBase = "http://localhost:" + port + "/fhir/";
@@ -39,6 +43,20 @@ class WellKnownControllerTest {
 
 		ourLog.info("response.getBody()->\n{}", response.getBody());
 		assertTrue(response.getBody().contains("launch-standalone"));
+		// ASSERT
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void testCapabilityStmt() {
+		// ARRANGE
+		RestTemplate restTemplate = new RestTemplate();
+
+		// ACT
+		ResponseEntity<String> response = restTemplate.getForEntity(ourServerBase + "/metadata", String.class);
+
+		ourLog.info("response.getBody()->\n{}", response.getBody());
+		assertTrue(response.getBody().contains(authorizationEndpoint));
 		// ASSERT
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 	}

--- a/src/test/resources/application-smart.yaml
+++ b/src/test/resources/application-smart.yaml
@@ -55,6 +55,7 @@ hapi:
         fhir_version: R4
 #see https://hl7.org/fhir/smart-app-launch/conformance.html#response
 smart: 
+  allowed_readonly_resources: Practitioner, PractitionerRole, Organization, OrganizationAffiliation, MedicationKnowledge, List, Location, HealthcareService
   wellknown: 
     issuer: https://test.org
     jwks_uri: https://test.org/protocol/openid-connect/certs

--- a/src/test/resources/application-smart.yaml
+++ b/src/test/resources/application-smart.yaml
@@ -68,5 +68,5 @@ smart:
     management_endpoint: 
     introspection_endpoint : 
     revocation_endpoint : 
-    capabilities: launch-standalone
+    capabilities: launch-standalone, client-public, client-confidential-symmetric, context-standalone-patient, permission-patient
     code_challenge_methods_supported: S256

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,36 @@
+<configuration scan="true" scanPeriod="30 seconds">
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+			<level>INFO</level>
+		</filter>  -->
+		<encoder>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level \(%file:%line\) %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.springframework.beans" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+	
+	<logger name="org.springframework.core" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+	
+	<logger name="ca.uhn.fhir" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+	
+	<logger name="ca.uhn.fhir.jpa.starter" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+	
+	<logger name="ca.uhn.fhir.rest.server.interceptor.auth" level="TRACE" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<root level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
This PR contains several things - in order of the commits:

1) Fix for the SearchNarrowingInteceptor  using the incorrect case (“patient” instead of “Patient”) – and thus allowing searches to resources not authorized.   

2) Allows/ignores unknown scopes - previously things like launch/patient would cause a request to be rejected

3) Added SMART elements to capability statement

4) Addition to prior PR for a smartAdmin group - extend so the SearchNarrowingInterceptor also supports the admin group
 
5a) Fixed bug where non-patient compartment resources are being allowed read-access in some cases
5b)  added the ability to explicitly allow read access to non-patient compartment resources via config
5c) Fixed bug where SmartScopeAuthorizationInterceptor.buildRules adds the same rules to the return list multiple times
