### PR TITLE
Smart/smart main

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/smart/SmartCapabilityStatementInterceptorR4.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/smart/SmartCapabilityStatementInterceptorR4.java
@@ -11,8 +11,6 @@ import org.hl7.fhir.r4.model.UriType;
 import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestComponent;
 import org.hl7.fhir.r4.model.CapabilityStatement.CapabilityStatementRestSecurityComponent;
 import org.hl7.fhir.r4.model.CapabilityStatement.RestfulCapabilityMode;
-import org.hl7.fhir.r4.model.CodeableConcept;
-import org.hl7.fhir.r4.model.Coding;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
@@ -73,9 +71,11 @@ public class SmartCapabilityStatementInterceptorR4 {
 		CapabilityStatementRestSecurityComponent securityComponent = new CapabilityStatementRestSecurityComponent();
 
 		// see http://hl7.org/fhir/smart-app-launch/1.0.0/conformance/index.html#example
-		CodeableConcept cc = securityComponent.addService();
-		cc.addCoding(new Coding("http://hl7.org/fhir/restful-security-service", "SMART-on-FHIR", null));
-		cc.setText("OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)");
+		// NOTE: this CodeableConcept is included in the in the smart example above, but it fails Touchstone validation
+		// and is not required by SMART per: https://chat.fhir.org/#narrow/stream/179170-smart/topic/SMART.20on.20FHIR.20v1.20System.20Links.20Broken
+		// CodeableConcept cc = securityComponent.addService();
+		// cc.addCoding(new Coding("http://hl7.org/fhir/restful-security-service", "SMART-on-FHIR", null));
+		// cc.setText("OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)");
 
 		Extension oauthExtension = new Extension();
 


### PR DESCRIPTION
First commit is minor - just a workaround for a flawed Touchstone test. 
Second commit  adds patient $everything support when patient/*.read or patient/*.* scopes are granted. 

NOTE: I discovered just calling:
rules.allow().operation().withAnyName().onInstance(idType)
does not create a rule, unless you close it with: 
.andAllowAllResponses();

There wasn't an existing test (I don't think)  that tests your applyResourceScopeOperationClassifier() method - but I added  .andAllowAllResponses()  there as well - I think it might prevent issues if that is ever in use. 